### PR TITLE
include NodeJS version 0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
 language: node_js
 node_js:
+  - "0.11"
   - "0.10"
   - "0.8"
+branches:
+  only:
+    - master
+matrix:
+  allow_failures:
+    - node_js: "0.11"
 notifications:
   email: false


### PR DESCRIPTION
Start including test runs against version 0.11 for Travis CI builds.
