### PR TITLE
Removed non-needed path module from deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,5 @@
     "yuitest": "*",
     "ytestrunner": "*",
     "coveralls": "~2.6.1"
-  },
-  "dependencies": {
-    "path": "~0.4.9"
   }
 }


### PR DESCRIPTION
You have the `path` module in your `dependencies`, this is not needed since it's a `builtin` Node.js module.

Also, it's not used in the code at all, only the tests.
