### PR TITLE
remove coveralls coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Feature flagging for NodeJS",
   "main": "index.js",
   "scripts": {
-    "test": "ytestrunner --coverage --istanbul cover --cov-include=index.js --cov-include=lib/* --cov-exclude=**/node_modules/** --save-coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf coverage"
+    "test": "ytestrunner --coverage --istanbul cover --cov-include=index.js --cov-include=lib/* --cov-exclude=**/node_modules/** --save-coverage && rm -rf coverage"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Temporarily remove coveralls support. Need to better configure the coverage so that it operates for all CI tools, not just Travis-CI

Related to Issue #42 
