### PR TITLE
Make load callback optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,9 @@ function update(data, callback) {
         }
     });
 
-    callback();
+    if(typeof callback === 'function') {
+      callback();
+    }
 }
 
 function load(filename, callback) {

--- a/test/index.func.test.js
+++ b/test/index.func.test.js
@@ -32,5 +32,22 @@ Y.TestRunner.add(new Y.TestCase({
         });
 
         me.wait(1000);
+    },
+
+    "load a set of features flags from file with no update callback": function () {
+      var me = this,
+        testFeatures = helper.loadDataFromFile(me.featureFile);
+
+      me.watcher = me.app.load(me.featureFile);
+
+      me.wait(function() {
+        Object.keys(testFeatures).forEach(function (feature) {
+            if (testFeatures.hasOwnProperty(feature)) {
+                Assert.areSame(testFeatures[feature], me.app.isEnabled(feature),
+                    'The feature "' + feature + '" is enabled by file loading.');
+            }
+        });
+      }, 1000);
+
     }
 }));


### PR DESCRIPTION
The README.md says that the update callback for the load function, however when a function is not passed in an error is generated.

I've wrapped the update callback in a quick check to see if it's a function and also added a test to cover this.

This is my first test I've written for node.js so I welcome comments on it as I'm convinced it's not the best way to test an optional callback parameter.